### PR TITLE
fix: allow `EditableComponent` to be garbage collected

### DIFF
--- a/projects/ngneat/edit-in-place/src/lib/editable.component.ts
+++ b/projects/ngneat/edit-in-place/src/lib/editable.component.ts
@@ -56,6 +56,12 @@ export class EditableComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.destroy$.next(true);
+    // Caretaker note: we're explicitly setting these subscriptions to `null` since this actually will be closed subscriptions,
+    // but they still keep referencing `destination`'s, which are `SafeSubscribers`. Destinations keep referencing `next` functions,
+    // which are `() => this.displayEditMode()` and `() => this.saveEdit()`.
+    // Since `next` functions capture `this`, this leads to a circular reference preventing the `EditableComponent` from being GC'd.
+    this.editHandler = null;
+    this.viewHandler = null;
   }
 
   private handleViewMode(): void {


### PR DESCRIPTION
Hey, I've found a memory leak when the `EditableComponent` cannot be GC'd (see code comments). The fix is simple:

![image](https://user-images.githubusercontent.com/7337691/125095910-5433b080-e0dd-11eb-801b-23527c20cfb4.png)
